### PR TITLE
- install required header

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 ACLOCAL_AMFLAGS = -I build-aux/m4
 
 lib_LTLIBRARIES = libsecp256k1.la
-include_HEADERS = include/secp256k1.h
+include_HEADERS = include/secp256k1.h include/secp256k1_recovery.h
 noinst_HEADERS =
 noinst_HEADERS += src/scalar.h
 noinst_HEADERS += src/scalar_4x64.h


### PR DESCRIPTION
This header is required and stops libbitcoin from being built if not installed.  The same change should be included in master.
