### PR TITLE
Adding correct include headers (for complete installation)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,11 @@
 ACLOCAL_AMFLAGS = -I build-aux/m4
 
 lib_LTLIBRARIES = libsecp256k1.la
-include_HEADERS = include/secp256k1.h
+include_HEADERS =
+include_HEADERS += include/secp256k1.h
+include_HEADERS += include/secp256k1_ecdh.h
+include_HEADERS += include/secp256k1_recovery.h
+include_HEADERS += include/secp256k1_schnorr.h
 noinst_HEADERS =
 noinst_HEADERS += src/scalar.h
 noinst_HEADERS += src/scalar_4x64.h


### PR DESCRIPTION
It seems that "secp256k1_recovery.h" are not installed into PREFIX/ by default, adding it and its friends.
