### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Build steps
 libsecp256k1 is built using autotools:
 
     $ ./autogen.sh
-    $ ./configure
+    $ ./configure --enable-module-recovery
     $ make
     $ ./tests
     $ sudo make install  # optional


### PR DESCRIPTION
Fixed issue with libbitcoin build because by default secp256k1_recovery.h is not included into the build (but required by libbitcoin)